### PR TITLE
Fix timeout call on exec_return_code

### DIFF
--- a/novamiko.py
+++ b/novamiko.py
@@ -117,8 +117,8 @@ class NovaMikoInstance(object):
         return std_out.readlines()
 
     def exec_return_code(self, cmd, timeout=None):
-        session = self.ssh.get_transport().open_session()
-        session.exec_command(self._add_paths(cmd), timeout=timeout)
+        session = self.ssh.get_transport().open_session(timeout=timeout)
+        session.exec_command(self._add_paths(cmd))
         return session.recv_exit_status()
 
     def destroy(self):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ description = "Wrapper around Openstack Nova and Paramiko"
 
 setup(
     name="novamiko",
-    version="0.0.5",
+    version="0.0.6",
     author="Andrew Melton",
     author_email="andrew.melton@rackspace.com",
     description=description,


### PR DESCRIPTION
- Previous commit incorrectly added timeout to the session.exec_command() method,
which does not include a timeout parameter
- Bumped version number